### PR TITLE
Use File.exist? for 3.2.0 compatibility

### DIFF
--- a/markdown-tools/lib/markdown/cli/runner.rb
+++ b/markdown-tools/lib/markdown/cli/runner.rb
@@ -24,7 +24,11 @@ class Runner
       
     Markdown.extnames.include?( extname.downcase )
   end
-    
+
+  def file_exists? ( fn )
+    (File.respond_to?( :exists? )) ? File.exists?( fn ) : File.exist?( fn )
+  end
+
   def find_file_with_markdown_extension( fn )
     dirname  = File.dirname( fn )
     basename = File.basename( fn, '.*' )
@@ -33,8 +37,8 @@ class Runner
 
     Markdown.extnames.each do |e|
       newname = File.join( dirname, "#{basename}#{e}" ) 
-      logger.debug "File.exists? #{newname}"
-      return newname if File.exists?( newname )
+      logger.debug "file_exists? #{newname}"
+      return newname if file_exists?( newname )
     end  # each extension (e)
       
     nil   # not found; return nil
@@ -85,7 +89,7 @@ class Runner
         end
       end
     else  # assume it's a single file (check for missing extension)
-      if File.exists?( file_or_dir_or_pattern )
+      if file_exists?( file_or_dir_or_pattern )
         file = file_or_dir_or_pattern
         if has_markdown_extension?( file )
           logger.debug "  adding file '#{file}'..."

--- a/markdown-tools/lib/markdown/cli/runner.rb
+++ b/markdown-tools/lib/markdown/cli/runner.rb
@@ -25,10 +25,6 @@ class Runner
     Markdown.extnames.include?( extname.downcase )
   end
 
-  def file_exists? ( fn )
-    (File.respond_to?( :exists? )) ? File.exists?( fn ) : File.exist?( fn )
-  end
-
   def find_file_with_markdown_extension( fn )
     dirname  = File.dirname( fn )
     basename = File.basename( fn, '.*' )
@@ -37,8 +33,8 @@ class Runner
 
     Markdown.extnames.each do |e|
       newname = File.join( dirname, "#{basename}#{e}" ) 
-      logger.debug "file_exists? #{newname}"
-      return newname if file_exists?( newname )
+      logger.debug "File.exist? #{newname}"
+      return newname if File.exist?( newname )
     end  # each extension (e)
       
     nil   # not found; return nil
@@ -89,7 +85,7 @@ class Runner
         end
       end
     else  # assume it's a single file (check for missing extension)
-      if file_exists?( file_or_dir_or_pattern )
+      if File.exist?( file_or_dir_or_pattern )
         file = file_or_dir_or_pattern
         if has_markdown_extension?( file )
           logger.debug "  adding file '#{file}'..."

--- a/markdown/lib/markdown/config.rb
+++ b/markdown/lib/markdown/config.rb
@@ -55,6 +55,10 @@ DEFAULTS_SERVICE = { 'libs' => [
              'redcarpet' => DEFAULT_REDCARPET
            }
 
+    def file_exists? ( fn )
+      return (File.respond_to?(:exists)) ? File.exists?(fn) : File.exist?(fn)
+    end
+
     def load_props
       @props = @props_default = Props.new( DEFAULTS, 'DEFAULTS' )
 
@@ -62,7 +66,7 @@ DEFAULTS_SERVICE = { 'libs' => [
 
       ## todo: use .markdown.yml?? or differnt name ??
       props_home_file = File.join( Env.home, 'markdown.yml' )
-      if File.exists?( props_home_file )
+      if file_exists?( props_home_file )
         puts "Loading home settings from '#{props_home_file}'..."
         @props = @props_home = Props.load_file( props_home_file, @props )
       end
@@ -70,7 +74,7 @@ DEFAULTS_SERVICE = { 'libs' => [
       # check for user settings (markdown.yml) in working folder
     
       props_work_file = File.join( '.', 'markdown.yml' )
-      if File.exists?( props_work_file )
+      if file_exists?( props_work_file )
         puts "Loading work settings from '#{props_work_file}'..."
         @props = @props_work = Props.load_file( props_work_file, @props )
       end

--- a/markdown/lib/markdown/config.rb
+++ b/markdown/lib/markdown/config.rb
@@ -55,10 +55,6 @@ DEFAULTS_SERVICE = { 'libs' => [
              'redcarpet' => DEFAULT_REDCARPET
            }
 
-    def file_exists? ( fn )
-      return (File.respond_to?(:exists)) ? File.exists?(fn) : File.exist?(fn)
-    end
-
     def load_props
       @props = @props_default = Props.new( DEFAULTS, 'DEFAULTS' )
 
@@ -66,7 +62,7 @@ DEFAULTS_SERVICE = { 'libs' => [
 
       ## todo: use .markdown.yml?? or differnt name ??
       props_home_file = File.join( Env.home, 'markdown.yml' )
-      if file_exists?( props_home_file )
+      if File.exist?( props_home_file )
         puts "Loading home settings from '#{props_home_file}'..."
         @props = @props_home = Props.load_file( props_home_file, @props )
       end
@@ -74,7 +70,7 @@ DEFAULTS_SERVICE = { 'libs' => [
       # check for user settings (markdown.yml) in working folder
     
       props_work_file = File.join( '.', 'markdown.yml' )
-      if file_exists?( props_work_file )
+      if File.exist?( props_work_file )
         puts "Loading work settings from '#{props_work_file}'..."
         @props = @props_work = Props.load_file( props_work_file, @props )
       end


### PR DESCRIPTION
Ever since updating some projects to [Ruby 3.2.0](https://stackoverflow.com/questions/48192762/did-ruby-deprecate-the-wrong-file-exists-method), this library was broken. The fix was to include a snippet like the following in the code:

``` ruby
unless File.respond_to?(:exists?)
  class << File
    alias_method :exists?, :exist?
  end
end
```

This PR includes a version of this fix to this library which should be compatible with versions both before and after 3.2.0.